### PR TITLE
Centre cards for screens-width <= 660px

### DIFF
--- a/static/sass/_projects.scss
+++ b/static/sass/_projects.scss
@@ -17,7 +17,12 @@ div.projects {
 
   &-view {
     display: flex;
-    flex-flow: row wrap;
+    flex-flow: row;
+
+    @media all and (max-width: 660px) {
+      flex-flow: column;
+      align-items: center;
+    }
   }
 }
 


### PR DESCRIPTION
If the screen reaches a width of 660px, then we switch the flex-flow to column and we centre the items.